### PR TITLE
Use fixed metadata helper for locale layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,7 +5,7 @@ import Script from "next/script";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import Providers from "./providers";
 import LayoutShell from "./components/LayoutShell";
-import { createPageMetadata, buildOrganizationJsonLd } from "@/lib/seo";
+import { buildOrganizationJsonLd, generatePageMetadata } from "@/lib/seo";
 import { getLocaleDirection, isValidLocale, loadMessages, type AppLocale } from "@/lib/i18n";
 import { loadArticles, loadListings } from "@/lib/data/loaders";
 import { createStaticKey } from "@/lib/swr-config";
@@ -24,12 +24,11 @@ export async function generateMetadata({
     notFound();
   }
 
-  const t = await getTranslations({ locale, namespace: "seo" });
-  return createPageMetadata({
+  return generatePageMetadata({
     locale: locale as AppLocale,
-    title: t("title"),
-    description: t("description"),
-    pathname: "",
+    pathname: "/",
+    title: "ZomZom Property",
+    description: "Boutique multilingual real estate experts guiding global buyers across Southeast Asia.",
   });
 }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -94,6 +94,8 @@ export function createPageMetadata({
   } satisfies Metadata;
 }
 
+export const generatePageMetadata = createPageMetadata;
+
 export function buildOrganizationJsonLd(locale: AppLocale) {
   return {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- update the locale layout to call the shared SEO helper with fixed metadata for the home path
- expose the helper as generatePageMetadata from the SEO utilities for future imports

## Testing
- pnpm lint *(fails: missing dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2dd42f0ec832bbd5364ef4700b1dd