### PR TITLE
Add structured data helpers and render organization JSON-LD

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,7 +5,7 @@ import ListingsGrid from "./components/ListingsGrid";
 import ArticlesCarousel from "./components/ArticlesCarousel";
 import Testimonials from "./components/Testimonials";
 import FaqAccordion from "./components/FaqAccordion";
-import { buildListingJsonLd } from "@/lib/seo";
+import { JsonLd, buildListingJsonLd, ldOrganization, ldWebsite } from "@/lib/seo";
 import {
   loadArticles,
   loadFaqs,
@@ -49,6 +49,9 @@ export default async function LocaleHome({ params }: { params: { locale: string 
 
   return (
     <>
+      <JsonLd {...ldOrganization(locale as AppLocale)} />
+      <JsonLd {...ldWebsite(locale as AppLocale)} />
+
       <Hero
         eyebrow={tHome("hero.eyebrow")}
         title={tHome("hero.title")}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Script from "next/script";
+import { createElement, type ReactElement } from "react";
 import { getHreflangLocales, routing, type AppLocale } from "@/lib/i18n";
 import type { Listing } from "@/lib/data/schemas";
 
@@ -96,6 +98,22 @@ export function createPageMetadata({
 
 export const generatePageMetadata = createPageMetadata;
 
+export type JsonLdProps = {
+  id: string;
+  data: unknown;
+};
+
+export function JsonLd({ id, data }: JsonLdProps): ReactElement {
+  return createElement(
+    Script,
+    {
+      id,
+      type: "application/ld+json",
+    },
+    JSON.stringify(data),
+  );
+}
+
 export function buildOrganizationJsonLd(locale: AppLocale) {
   return {
     "@context": "https://schema.org",
@@ -109,6 +127,32 @@ export function buildOrganizationJsonLd(locale: AppLocale) {
       "https://www.facebook.com/zomzomproperty",
       "https://www.instagram.com/zomzomproperty",
     ],
+  };
+}
+
+export function ldOrganization(locale: AppLocale): JsonLdProps {
+  return {
+    id: `ld-organization-${locale}`,
+    data: buildOrganizationJsonLd(locale),
+  };
+}
+
+export function buildWebsiteJsonLd(locale: AppLocale) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    url: getAbsoluteUrl(`/${locale}`),
+    inLanguage: locale,
+    alternateName: `${SITE_NAME} Southeast Asia Real Estate`,
+  };
+}
+
+export function ldWebsite(locale: AppLocale): JsonLdProps {
+  return {
+    id: `ld-website-${locale}`,
+    data: buildWebsiteJsonLd(locale),
   };
 }
 


### PR DESCRIPTION
## Summary
- add reusable JsonLd helper and functions for organization and website schemas
- render organization and website JSON-LD in the localized home page while keeping listing schema output

## Testing
- pnpm lint *(fails: missing dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de8d8ae4832b9cf7eb69c98a0998