### PR TITLE
Add .gitattributes rules for text normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+*.md text eol=lf
+scripts/** text eol=lf
+.husky/** text eol=lf


### PR DESCRIPTION
## Summary
- add a repository-level `.gitattributes` file to normalize text files
- enforce LF line endings for Markdown, scripts, and Husky files

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2e14d7ae8832bb54218704e17a044