### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- add a repository-wide `.editorconfig` to standardize UTF-8 encoding, LF line endings, space indentation, and trailing whitespace handling
- exempt Markdown files from trailing whitespace trimming rules

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2e1d6b150832ba5a860ac39af9f74