### PR TITLE
Update locale switcher to preserve URL details

### DIFF
--- a/src/app/[locale]/components/LocaleSwitcher.tsx
+++ b/src/app/[locale]/components/LocaleSwitcher.tsx
@@ -1,30 +1,24 @@
-"use client";
+'use client';
 
-import { useLocale } from "next-intl";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState, useTransition } from "react";
-import { getLocaleLabel, locales } from "@/lib/i18n";
-import { cn } from "@/lib/utils";
+import { useLocale } from 'next-intl';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { getLocaleLabel, locales } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
 
 export default function LocaleSwitcher({ className }: { className?: string }) {
   const locale = useLocale();
   const pathname = usePathname();
   const router = useRouter();
-  const [hash, setHash] = useState<string>("");
-  const [isPending, startTransition] = useTransition();
+  const searchParams = useSearchParams();
+  const [hash, setHash] = useState<string>('');
 
   useEffect(() => {
-    setHash(window.location.hash ?? "");
-  }, [pathname]);
-
-  const pathWithoutLocale = useMemo(() => {
-    if (!pathname) return "";
-    const segments = pathname.split("/").filter(Boolean);
-    return segments.slice(1).join("/");
-  }, [pathname]);
+    setHash(window.location.hash ?? '');
+  }, []);
 
   return (
-    <label className={cn("flex items-center gap-2 text-sm", className)}>
+    <label className={cn('flex items-center gap-2 text-sm', className)}>
       <span className="sr-only">Switch language</span>
       <select
         className="rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-sm font-medium shadow-sm transition focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200"
@@ -32,12 +26,22 @@ export default function LocaleSwitcher({ className }: { className?: string }) {
         aria-label="Switch language"
         onChange={(event) => {
           const nextLocale = event.target.value;
-          startTransition(() => {
-            const suffix = pathWithoutLocale ? `/${pathWithoutLocale}` : "";
-            router.push(`/${nextLocale}${suffix}${hash}`);
-          });
+          if (!pathname) return;
+
+          const segments = pathname.split('/').filter(Boolean);
+
+          if (segments.length === 0) {
+            segments.push(nextLocale);
+          } else {
+            segments[0] = nextLocale;
+          }
+
+          const nextPath = `/${segments.join('/')}`;
+          const search = searchParams.toString();
+          const nextUrl = `${nextPath}${search ? `?${search}` : ''}${hash}`;
+
+          router.replace(nextUrl, { scroll: false });
         }}
-        disabled={isPending}
       >
         {locales.map((availableLocale) => (
           <option key={availableLocale} value={availableLocale}>


### PR DESCRIPTION
## Summary
- capture the current hash on mount and use search parameters when computing locale switch URLs
- rebuild the destination URL by swapping the locale segment while keeping search params and hashes
- navigate with router.replace to avoid push transitions and disable scroll jumps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e7f49d9c832bbec7bfe484d78f16