### PR TITLE
Refactor breadcrumb component to use pathname

### DIFF
--- a/src/app/[locale]/articles/[slug]/page.tsx
+++ b/src/app/[locale]/articles/[slug]/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-import Script from "next/script";
-import { getTranslations } from "next-intl/server";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import { loadArticles } from "@/lib/data/loaders";
-import { formatDate } from "@/lib/utils";
-import { createPageMetadata, getAbsoluteUrl } from "@/lib/seo";
-import type { AppLocale } from "@/lib/i18n";
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Script from 'next/script';
+import { getTranslations } from 'next-intl/server';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { loadArticles } from '@/lib/data/loaders';
+import { formatDate } from '@/lib/utils';
+import { createPageMetadata, getAbsoluteUrl } from '@/lib/seo';
+import type { AppLocale } from '@/lib/i18n';
 
 export async function generateStaticParams() {
   const articles = loadArticles();
@@ -24,12 +24,12 @@ export async function generateMetadata({
   if (!article) {
     return createPageMetadata({
       locale: locale as AppLocale,
-      title: "Article",
-      description: "",
+      title: 'Article',
+      description: '',
       pathname: `/articles/${slug}`,
     });
   }
-  const t = await getTranslations({ locale, namespace: "articles" });
+  const t = await getTranslations({ locale, namespace: 'articles' });
   return createPageMetadata({
     locale: locale as AppLocale,
     title: t(`items.${article.id}.title`),
@@ -50,14 +50,11 @@ export default async function ArticleDetail({
     notFound();
   }
 
-  const [tCommon, tArticles] = await Promise.all([
-    getTranslations({ locale, namespace: "common" }),
-    getTranslations({ locale, namespace: "articles" }),
-  ]);
+  const tArticles = await getTranslations({ locale, namespace: 'articles' });
 
   const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Article",
+    '@context': 'https://schema.org',
+    '@type': 'Article',
     headline: tArticles(`items.${article.id}.title`),
     description: tArticles(`items.${article.id}.excerpt`),
     datePublished: article.published,
@@ -66,21 +63,19 @@ export default async function ArticleDetail({
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs
-        homeLabel={tCommon("home")}
-        homeHref={`/${locale}`}
-        items={[
-          { label: tArticles("sectionTitle"), href: `/${locale}/articles` },
-          { label: tArticles(`items.${article.id}.title`) },
-        ]}
-      />
+      <Breadcrumbs />
       <article className="mt-8 space-y-6">
         <header className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-brand-500">
-            {formatDate(article.published, locale)} · {tArticles("readTime", { minutes: article.readingMinutes })}
+            {formatDate(article.published, locale)} ·{' '}
+            {tArticles('readTime', { minutes: article.readingMinutes })}
           </p>
-          <h1 className="text-3xl font-semibold text-slate-900">{tArticles(`items.${article.id}.title`)}</h1>
-          <p className="text-sm text-slate-600">{tArticles(`items.${article.id}.excerpt`)}</p>
+          <h1 className="text-3xl font-semibold text-slate-900">
+            {tArticles(`items.${article.id}.title`)}
+          </h1>
+          <p className="text-sm text-slate-600">
+            {tArticles(`items.${article.id}.excerpt`)}
+          </p>
         </header>
         <div className="prose prose-slate max-w-none text-sm leading-relaxed">
           {article.bodyKeys.map((key) => (

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import Script from "next/script";
-import Link from "next/link";
-import Breadcrumbs from "../components/Breadcrumbs";
-import { loadArticles } from "@/lib/data/loaders";
-import { formatDate } from "@/lib/utils";
-import { createPageMetadata, getAbsoluteUrl } from "@/lib/seo";
-import type { AppLocale } from "@/lib/i18n";
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import Script from 'next/script';
+import Link from 'next/link';
+import Breadcrumbs from '../components/Breadcrumbs';
+import { loadArticles } from '@/lib/data/loaders';
+import { formatDate } from '@/lib/utils';
+import { createPageMetadata, getAbsoluteUrl } from '@/lib/seo';
+import type { AppLocale } from '@/lib/i18n';
 
 export async function generateMetadata({
   params,
@@ -14,29 +14,28 @@ export async function generateMetadata({
   params: { locale: string };
 }): Promise<Metadata> {
   const { locale } = params;
-  const t = await getTranslations({ locale, namespace: "articles" });
+  const t = await getTranslations({ locale, namespace: 'articles' });
   return createPageMetadata({
     locale: locale as AppLocale,
-    title: t("seo.title"),
-    description: t("seo.description"),
-    pathname: "/articles",
+    title: t('seo.title'),
+    description: t('seo.description'),
+    pathname: '/articles',
   });
 }
 
 export default async function ArticlesPage({ params }: { params: { locale: string } }) {
   const { locale } = params;
-  const [tCommon, tArticles, articles] = await Promise.all([
-    getTranslations({ locale, namespace: "common" }),
-    getTranslations({ locale, namespace: "articles" }),
+  const [tArticles, articles] = await Promise.all([
+    getTranslations({ locale, namespace: 'articles' }),
     loadArticles(),
   ]);
 
   const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: tArticles("sectionTitle"),
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: tArticles('sectionTitle'),
     itemListElement: articles.items.map((article, index) => ({
-      "@type": "ListItem",
+      '@type': 'ListItem',
       position: index + 1,
       url: getAbsoluteUrl(`/${locale}/articles/${article.slug}`),
       name: tArticles(`items.${article.id}.title`),
@@ -45,30 +44,35 @@ export default async function ArticlesPage({ params }: { params: { locale: strin
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs
-        homeLabel={tCommon("home")}
-        homeHref={`/${locale}`}
-        items={[{ label: tArticles("sectionTitle") }]}
-      />
+      <Breadcrumbs />
       <header className="mt-8 space-y-3">
-        <h1 className="text-3xl font-semibold text-slate-900">{tArticles("sectionTitle")}</h1>
-        <p className="text-sm text-slate-600">{tArticles("sectionSubtitle")}</p>
+        <h1 className="text-3xl font-semibold text-slate-900">
+          {tArticles('sectionTitle')}
+        </h1>
+        <p className="text-sm text-slate-600">{tArticles('sectionSubtitle')}</p>
       </header>
       <div className="mt-10 space-y-8">
         {articles.items.map((article) => (
-          <article key={article.id} className="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-soft">
+          <article
+            key={article.id}
+            className="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-soft"
+          >
             <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-wide text-brand-500">
               <span>{formatDate(article.published, locale)}</span>
               <span>·</span>
-              <span>{tArticles("readTime", { minutes: article.readingMinutes })}</span>
+              <span>{tArticles('readTime', { minutes: article.readingMinutes })}</span>
             </div>
-            <h2 className="mt-4 text-2xl font-semibold text-slate-900">{tArticles(`items.${article.id}.title`)}</h2>
-            <p className="mt-2 text-sm text-slate-600">{tArticles(`items.${article.id}.excerpt`)}</p>
+            <h2 className="mt-4 text-2xl font-semibold text-slate-900">
+              {tArticles(`items.${article.id}.title`)}
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              {tArticles(`items.${article.id}.excerpt`)}
+            </p>
             <Link
               href={`/${locale}/articles/${article.slug}`}
               className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition hover:text-brand-500"
             >
-              {tArticles("readMore")}
+              {tArticles('readMore')}
               <span aria-hidden>→</span>
             </Link>
           </article>

--- a/src/app/[locale]/components/Breadcrumbs.tsx
+++ b/src/app/[locale]/components/Breadcrumbs.tsx
@@ -1,44 +1,155 @@
-import Link from "next/link";
-import { cn } from "@/lib/utils";
+'use client';
 
-type BreadcrumbItem = {
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { getAbsoluteUrl } from '@/lib/seo';
+import type { Article } from '@/lib/data/schemas';
+import articles from '@/lib/data/articles.json';
+
+type Breadcrumb = {
   label: string;
   href?: string;
+  fullPath: string;
 };
 
-export default function Breadcrumbs({
-  homeLabel,
-  homeHref,
-  items,
-}: {
-  homeLabel: string;
-  homeHref: string;
-  items: BreadcrumbItem[];
-}) {
+const articleSlugToTitleKey = new Map(
+  (articles as Article[]).map((article) => [article.slug, article.titleKey]),
+);
+
+function stripNamespace(key: string, namespace: string) {
+  const prefix = `${namespace}.`;
+  return key.startsWith(prefix) ? key.slice(prefix.length) : key;
+}
+
+function formatSegment(segment: string) {
+  return decodeURIComponent(segment)
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default function Breadcrumbs() {
+  const pathname = usePathname();
+  const locale = useLocale();
+  const tCommon = useTranslations('common');
+  const tListings = useTranslations('listings');
+  const tArticles = useTranslations('articles');
+  const tContact = useTranslations('contact');
+
+  const breadcrumbs = useMemo<Breadcrumb[]>(() => {
+    if (!pathname) {
+      return [];
+    }
+
+    const segments = pathname.split('/').filter(Boolean);
+    const localeIndex = segments.indexOf(locale);
+    const pathSegments = localeIndex === -1 ? segments : segments.slice(localeIndex + 1);
+
+    const items: Breadcrumb[] = [];
+    const homePath = `/${locale}`;
+    const hasSegments = pathSegments.length > 0;
+
+    items.push({
+      label: tCommon('home'),
+      href: hasSegments ? homePath : undefined,
+      fullPath: homePath,
+    });
+
+    pathSegments.forEach((segment, index) => {
+      const isLast = index === pathSegments.length - 1;
+      const fullPath = `/${[locale, ...pathSegments.slice(0, index + 1)].join('/')}`;
+
+      const label = (() => {
+        if (segment === 'listings') {
+          return tListings('sectionTitle');
+        }
+        if (segment === 'articles') {
+          return tArticles('sectionTitle');
+        }
+        if (segment === 'contact') {
+          return tContact('title');
+        }
+
+        const articleTitleKey = articleSlugToTitleKey.get(segment);
+        if (articleTitleKey) {
+          return tArticles(stripNamespace(articleTitleKey, 'articles'));
+        }
+
+        return formatSegment(segment);
+      })();
+
+      items.push({
+        label,
+        href: isLast ? undefined : fullPath,
+        fullPath,
+      });
+    });
+
+    return items;
+  }, [locale, pathname, tArticles, tCommon, tContact, tListings]);
+
+  const breadcrumbJsonLd = useMemo(() => {
+    if (breadcrumbs.length === 0) {
+      return null;
+    }
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: breadcrumbs.map((breadcrumb, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: breadcrumb.label,
+        item: getAbsoluteUrl(breadcrumb.fullPath),
+      })),
+    };
+  }, [breadcrumbs]);
+
+  if (breadcrumbs.length === 0) {
+    return null;
+  }
+
   return (
-    <nav aria-label="Breadcrumb" className="text-sm">
-      <ol className="flex flex-wrap items-center gap-2 text-slate-500">
-        <li>
-          <Link href={homeHref} className="font-medium text-slate-600 transition hover:text-brand-600">
-            {homeLabel}
-          </Link>
-        </li>
-        {items.map((item, index) => (
-          <li key={item.label} className="flex items-center gap-2">
-            <span className="text-slate-400">/</span>
-            {item.href && index !== items.length - 1 ? (
-              <Link
-                href={item.href}
-                className={cn("transition hover:text-brand-600", "text-slate-600")}
-              >
-                {item.label}
-              </Link>
-            ) : (
-              <span className="text-slate-800">{item.label}</span>
-            )}
-          </li>
-        ))}
-      </ol>
-    </nav>
+    <>
+      <nav aria-label="Breadcrumb" className="text-sm">
+        <ol className="flex flex-wrap items-center gap-2 text-slate-500">
+          {breadcrumbs.map((breadcrumb, index) => {
+            const isFirst = index === 0;
+            const isLast = index === breadcrumbs.length - 1;
+
+            return (
+              <li key={breadcrumb.fullPath} className="flex items-center gap-2">
+                {!isFirst && <span className="text-slate-400">/</span>}
+                {breadcrumb.href ? (
+                  <Link
+                    href={breadcrumb.href}
+                    className={cn(
+                      'font-medium text-slate-600 transition hover:text-brand-600',
+                      { 'text-slate-800': isLast },
+                    )}
+                  >
+                    {breadcrumb.label}
+                  </Link>
+                ) : (
+                  <span className="text-slate-800">{breadcrumb.label}</span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+      {breadcrumbJsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(breadcrumbJsonLd),
+          }}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import Breadcrumbs from "../components/Breadcrumbs";
-import ContactForm, { type ContactCopy } from "./ContactForm";
-import { createPageMetadata } from "@/lib/seo";
-import type { AppLocale } from "@/lib/i18n";
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import Breadcrumbs from '../components/Breadcrumbs';
+import ContactForm, { type ContactCopy } from './ContactForm';
+import { createPageMetadata } from '@/lib/seo';
+import type { AppLocale } from '@/lib/i18n';
 
-const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "turnstile-site-key";
+const TURNSTILE_SITE_KEY =
+  process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? 'turnstile-site-key';
 
 export async function generateMetadata({
   params,
@@ -13,49 +14,42 @@ export async function generateMetadata({
   params: { locale: string };
 }): Promise<Metadata> {
   const { locale } = params;
-  const t = await getTranslations({ locale, namespace: "contact" });
+  const t = await getTranslations({ locale, namespace: 'contact' });
   return createPageMetadata({
     locale: locale as AppLocale,
-    title: t("seo.title"),
-    description: t("seo.description"),
-    pathname: "/contact",
+    title: t('seo.title'),
+    description: t('seo.description'),
+    pathname: '/contact',
   });
 }
 
 export default async function ContactPage({ params }: { params: { locale: string } }) {
   const { locale } = params;
-  const [tCommon, tContact] = await Promise.all([
-    getTranslations({ locale, namespace: "common" }),
-    getTranslations({ locale, namespace: "contact" }),
-  ]);
+  const tContact = await getTranslations({ locale, namespace: 'contact' });
 
   const copy: ContactCopy = {
-    intro: tContact("intro"),
+    intro: tContact('intro'),
     fields: {
-      name: tContact("fields.name"),
-      email: tContact("fields.email"),
-      phone: tContact("fields.phone"),
-      budget: tContact("fields.budget"),
-      message: tContact("fields.message"),
+      name: tContact('fields.name'),
+      email: tContact('fields.email'),
+      phone: tContact('fields.phone'),
+      budget: tContact('fields.budget'),
+      message: tContact('fields.message'),
     },
-    submit: tContact("submit"),
-    sending: tContact("sending"),
-    success: tContact("success"),
-    error: tContact("error"),
-    cooldown: tContact("cooldown"),
-    honeypot: tContact("honeypot"),
+    submit: tContact('submit'),
+    sending: tContact('sending'),
+    success: tContact('success'),
+    error: tContact('error'),
+    cooldown: tContact('cooldown'),
+    honeypot: tContact('honeypot'),
   };
 
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs
-        homeLabel={tCommon("home")}
-        homeHref={`/${locale}`}
-        items={[{ label: tContact("title") }]}
-      />
+      <Breadcrumbs />
       <div className="mt-8 space-y-4">
-        <h1 className="text-3xl font-semibold text-slate-900">{tContact("title")}</h1>
-        <p className="text-sm text-slate-600">{tContact("subtitle")}</p>
+        <h1 className="text-3xl font-semibold text-slate-900">{tContact('title')}</h1>
+        <p className="text-sm text-slate-600">{tContact('subtitle')}</p>
       </div>
       <div className="mt-10 rounded-3xl border border-slate-200/60 bg-white/80 p-8 shadow-soft">
         <ContactForm locale={locale} copy={copy} turnstileSiteKey={TURNSTILE_SITE_KEY} />

--- a/src/app/[locale]/listings/page.tsx
+++ b/src/app/[locale]/listings/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from "next";
-import Script from "next/script";
-import { getTranslations } from "next-intl/server";
-import Breadcrumbs from "../components/Breadcrumbs";
-import { loadListings } from "@/lib/data/loaders";
-import { formatCurrency } from "@/lib/utils";
-import type { AppLocale } from "@/lib/i18n";
-import { buildListingJsonLd, createPageMetadata } from "@/lib/seo";
+import type { Metadata } from 'next';
+import Script from 'next/script';
+import { getTranslations } from 'next-intl/server';
+import Breadcrumbs from '../components/Breadcrumbs';
+import { loadListings } from '@/lib/data/loaders';
+import { formatCurrency } from '@/lib/utils';
+import type { AppLocale } from '@/lib/i18n';
+import { buildListingJsonLd, createPageMetadata } from '@/lib/seo';
 
 export async function generateMetadata({
   params,
@@ -13,35 +13,34 @@ export async function generateMetadata({
   params: { locale: string };
 }): Promise<Metadata> {
   const { locale } = params;
-  const t = await getTranslations({ locale, namespace: "listings" });
+  const t = await getTranslations({ locale, namespace: 'listings' });
   return createPageMetadata({
     locale: locale as AppLocale,
-    title: t("seo.title"),
-    description: t("seo.description"),
-    pathname: "/listings",
+    title: t('seo.title'),
+    description: t('seo.description'),
+    pathname: '/listings',
   });
 }
 
 export default async function ListingsPage({ params }: { params: { locale: string } }) {
   const { locale } = params;
-  const [tCommon, tListings, listings] = await Promise.all([
-    getTranslations({ locale, namespace: "common" }),
-    getTranslations({ locale, namespace: "listings" }),
+  const [tListings, listings] = await Promise.all([
+    getTranslations({ locale, namespace: 'listings' }),
     loadListings(),
   ]);
 
-  const listingJsonLd = listings.items.map((listing) => buildListingJsonLd(locale as AppLocale, listing));
+  const listingJsonLd = listings.items.map((listing) =>
+    buildListingJsonLd(locale as AppLocale, listing),
+  );
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs
-        homeLabel={tCommon("home")}
-        homeHref={`/${locale}`}
-        items={[{ label: tListings("sectionTitle") }]}
-      />
+      <Breadcrumbs />
       <div className="mt-8 space-y-4">
-        <h1 className="text-3xl font-semibold text-slate-900">{tListings("sectionTitle")}</h1>
-        <p className="text-sm text-slate-600">{tListings("directorySubtitle")}</p>
+        <h1 className="text-3xl font-semibold text-slate-900">
+          {tListings('sectionTitle')}
+        </h1>
+        <p className="text-sm text-slate-600">{tListings('directorySubtitle')}</p>
       </div>
       <div className="mt-10 grid gap-6 md:grid-cols-2">
         {listings.items.map((listing) => (
@@ -51,20 +50,24 @@ export default async function ListingsPage({ params }: { params: { locale: strin
                 <span key={tag}>{tListings(`tags.${tag}`)}</span>
               ))}
             </div>
-            <h2 className="mt-4 text-xl font-semibold text-slate-900">{tListings(`items.${listing.id}.title`)}</h2>
-            <p className="mt-2 text-sm text-slate-600">{tListings(`items.${listing.id}.description`)}</p>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">
+              {tListings(`items.${listing.id}.title`)}
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              {tListings(`items.${listing.id}.description`)}
+            </p>
             <dl className="mt-6 grid grid-cols-3 gap-3 text-center text-xs text-slate-500">
               <div className="rounded-lg border border-slate-200/60 bg-white/70 p-2">
                 <dt className="font-semibold text-slate-700">{listing.bedrooms}</dt>
-                <dd>{tListings("metrics.bedrooms")}</dd>
+                <dd>{tListings('metrics.bedrooms')}</dd>
               </div>
               <div className="rounded-lg border border-slate-200/60 bg-white/70 p-2">
                 <dt className="font-semibold text-slate-700">{listing.bathrooms}</dt>
-                <dd>{tListings("metrics.bathrooms")}</dd>
+                <dd>{tListings('metrics.bathrooms')}</dd>
               </div>
               <div className="rounded-lg border border-slate-200/60 bg-white/70 p-2">
                 <dt className="font-semibold text-slate-700">{listing.area} m²</dt>
-                <dd>{tListings("metrics.area")}</dd>
+                <dd>{tListings('metrics.area')}</dd>
               </div>
             </dl>
             <div className="mt-6 flex items-center justify-between text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- replace the breadcrumb component with a client-side implementation that derives segments from the current pathname, maps known slugs to localized labels, and emits schema.org JSON-LD
- update listing, article, and contact pages to consume the new zero-prop breadcrumb component while retaining existing localization helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e8bfbb3c832b95795d9dbaaba35c