### PR TITLE
Refine intl middleware and fix build type issues

### DIFF
--- a/src/app/[locale]/components/Breadcrumbs.tsx
+++ b/src/app/[locale]/components/Breadcrumbs.tsx
@@ -129,7 +129,7 @@ export default function Breadcrumbs() {
                     href={breadcrumb.href}
                     className={cn(
                       'font-medium text-slate-600 transition hover:text-brand-600',
-                      { 'text-slate-800': isLast },
+                      isLast ? 'text-slate-800' : undefined,
                     )}
                   >
                     {breadcrumb.label}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,18 +1,18 @@
-import { getRequestConfig } from "next-intl/server";
-import { createTranslator } from "next-intl";
-import { notFound } from "next/navigation";
+import { getRequestConfig } from 'next-intl/server';
+import { createTranslator, type AbstractIntlMessages } from 'next-intl';
+import { notFound } from 'next/navigation';
 
-export const locales = ["th", "en", "zh-CN", "zh-TW", "my", "ru"] as const;
+export const locales = ['th', 'en', 'zh-CN', 'zh-TW', 'my', 'ru'] as const;
 export type AppLocale = (typeof locales)[number];
-export const fallbackLocale: AppLocale = "en";
+export const fallbackLocale: AppLocale = 'en';
 
 export const localeNames: Record<AppLocale, string> = {
-  th: "ไทย",
-  en: "English",
-  "zh-CN": "简体中文",
-  "zh-TW": "繁體中文",
-  my: "မြန်မာ",
-  ru: "Русский",
+  th: 'ไทย',
+  en: 'English',
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+  my: 'မြန်မာ',
+  ru: 'Русский',
 };
 
 const rtlLocales = new Set<AppLocale>();
@@ -20,14 +20,16 @@ const rtlLocales = new Set<AppLocale>();
 export const routing = {
   locales,
   defaultLocale: fallbackLocale,
-  localePrefix: "always" as const,
+  localePrefix: 'always' as const,
 };
 
 export function isValidLocale(locale: string): locale is AppLocale {
   return locales.includes(locale as AppLocale);
 }
 
-export async function loadMessages(locale: string) {
+export async function loadMessages(
+  locale: string,
+): Promise<{ locale: AppLocale; messages: AbstractIntlMessages }> {
   const resolved = isValidLocale(locale) ? locale : fallbackLocale;
   try {
     const messages = (await import(`../messages/${resolved}.json`)).default;
@@ -46,11 +48,11 @@ export async function createAppTranslator(locale: string) {
   return createTranslator({ locale: resolved, messages });
 }
 
-export function getLocaleDirection(locale: string): "ltr" | "rtl" {
+export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
   if (isValidLocale(locale) && rtlLocales.has(locale)) {
-    return "rtl";
+    return 'rtl';
   }
-  return "ltr";
+  return 'ltr';
 }
 
 export function getLocaleLabel(locale: string) {
@@ -60,12 +62,12 @@ export function getLocaleLabel(locale: string) {
   return localeNames[fallbackLocale];
 }
 
-export function getHreflangLocales(current: AppLocale, pathname = "") {
-  const cleanPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
-  const normalizedPath = cleanPath.replace(/^\/[a-zA-Z-]+/, "");
-  const basePath = normalizedPath.startsWith("/") ? normalizedPath : `/${normalizedPath}`;
+export function getHreflangLocales(current: AppLocale, pathname = '') {
+  const cleanPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const normalizedPath = cleanPath.replace(/^\/[a-zA-Z-]+/, '');
+  const basePath = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`;
   return Object.fromEntries(
-    locales.map((locale) => [locale, `/${locale}${basePath === "/" ? "" : basePath}`])
+    locales.map((locale) => [locale, `/${locale}${basePath === '/' ? '' : basePath}`]),
   );
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,25 @@
-import createMiddleware from "next-intl/middleware";
-import { routing } from "@/lib/i18n";
+import { NextRequest, NextResponse } from 'next/server';
+import createMiddleware from 'next-intl/middleware';
 
-export default createMiddleware(routing);
+import { routing } from '@/lib/i18n';
+
+const handleI18nRouting = createMiddleware(routing);
+
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.includes('.')
+  ) {
+    return NextResponse.next();
+  }
+
+  return handleI18nRouting(request);
+}
 
 export const config = {
-  matcher: ["/", "/(?!api|_next|.*\\..*).+"],
+  matcher: ['/:path*'],
 };


### PR DESCRIPTION
## Summary
- replace the `next-intl` middleware helper with a manual function that skips API/static routes while still delegating to the locale router
- resolve type issues in the breadcrumbs component by avoiding object-based class names
- annotate `loadMessages` with an explicit return type so its recursive fallback stays type-safe

## Testing
- npm run dev
- npm run build *(fails: multiple MISSING_MESSAGE errors during prerender along with missing suspense boundaries and downstream locale destructure failures already present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ed00f37c832ba071aa0bcd9c5206