### PR TITLE
Add i18n fallback handlers

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -81,5 +81,9 @@ export default getRequestConfig(async ({ locale }) => {
   return {
     locale,
     messages,
+    onError: () => {
+      /* noop */
+    },
+    getMessageFallback: ({ key }) => key,
   };
 });


### PR DESCRIPTION
## Summary
- add a no-op onError handler to the i18n request config
- configure message fallback to return the missing key for graceful degradation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f364ecb4832b916be496a2f15f0e