### PR TITLE
feat: add client listings search handling

### DIFF
--- a/src/__tests__/locale-switcher.test.tsx
+++ b/src/__tests__/locale-switcher.test.tsx
@@ -1,34 +1,35 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import LocaleSwitcher from "@/app/[locale]/components/LocaleSwitcher";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LocaleSwitcher from '@/app/[locale]/components/LocaleSwitcher';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const pushMock = vi.fn();
+const replaceMock = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  usePathname: () => "/en/articles",
-  useRouter: () => ({ push: pushMock }),
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/en/articles',
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
-vi.mock("next-intl", async () => {
-  const actual = await vi.importActual<typeof import("next-intl")>("next-intl");
+vi.mock('next-intl', async () => {
+  const actual = await vi.importActual<typeof import('next-intl')>('next-intl');
   return {
     ...actual,
-    useLocale: () => "en",
+    useLocale: () => 'en',
   };
 });
 
-describe("LocaleSwitcher", () => {
+describe('LocaleSwitcher', () => {
   beforeEach(() => {
-    pushMock.mockClear();
-    window.location.hash = "#hero";
+    replaceMock.mockClear();
+    window.location.hash = '#hero';
   });
 
-  it("preserves the current path and hash when switching locale", async () => {
+  it('preserves the current path and hash when switching locale', async () => {
     render(<LocaleSwitcher />);
-    const select = screen.getByRole("combobox", { name: /switch language/i });
-    await userEvent.selectOptions(select, "th");
-    expect(pushMock).toHaveBeenCalledWith("/th/articles#hero");
+    const select = screen.getByRole('combobox', { name: /switch language/i });
+    await userEvent.selectOptions(select, 'th');
+    expect(replaceMock).toHaveBeenCalledWith('/th/articles#hero', { scroll: false });
   });
 });

--- a/src/app/[locale]/listings/ListingsSearchClient.tsx
+++ b/src/app/[locale]/listings/ListingsSearchClient.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import type { ComponentProps } from 'react';
+import ListingsGrid from '../components/ListingsGrid';
+import type { AppLocale } from '@/lib/i18n';
+
+type ListingsGridProps = ComponentProps<typeof ListingsGrid>;
+
+type Props = Omit<ListingsGridProps, 'locale' | 'query' | 'tag'> & {
+  locale: AppLocale;
+};
+
+export default function ListingsSearchClient({ locale, ...gridProps }: Props) {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q');
+  const tag = searchParams.get('tag');
+
+  return <ListingsGrid {...gridProps} locale={locale} query={query} tag={tag} />;
+}


### PR DESCRIPTION
## Summary
- add a listings search client that reads `q`/`tag` from the URL and feeds them to the grid
- extend the listings grid to support locale-aware filtering and optional view-all controls
- statically generate listing routes per locale, wrap the client grid in suspense, and update tests for the new navigation mocks

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2f48559c0832bae30b020c5339978