### PR TITLE
Normalize locale handling for localized routes

### DIFF
--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -6,25 +6,34 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import { loadArticles } from '@/lib/data/loaders';
 import { formatDate } from '@/lib/utils';
 import { createPageMetadata, getAbsoluteUrl } from '@/lib/seo';
-import type { AppLocale } from '@/lib/i18n';
+import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
 
 export async function generateMetadata({
   params,
 }: {
-  params: { locale: string };
+  params: { locale?: string };
 }): Promise<Metadata> {
-  const { locale } = params;
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
+  const appLocale = locale as AppLocale;
   const t = await getTranslations({ locale, namespace: 'articles' });
   return createPageMetadata({
-    locale: locale as AppLocale,
+    locale: appLocale,
     title: t('seo.title'),
     description: t('seo.description'),
     pathname: '/articles',
   });
 }
 
-export default async function ArticlesPage({ params }: { params: { locale: string } }) {
-  const { locale } = params;
+export default async function ArticlesPage({ params }: { params: { locale?: string } }) {
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
   const [tArticles, articles] = await Promise.all([
     getTranslations({ locale, namespace: 'articles' }),
     loadArticles(),

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -3,7 +3,13 @@ import { getTranslations } from 'next-intl/server';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ContactForm, { type ContactCopy } from './ContactForm';
 import { createPageMetadata } from '@/lib/seo';
-import type { AppLocale } from '@/lib/i18n';
+import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
 
 const TURNSTILE_SITE_KEY =
   process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? 'turnstile-site-key';
@@ -11,20 +17,23 @@ const TURNSTILE_SITE_KEY =
 export async function generateMetadata({
   params,
 }: {
-  params: { locale: string };
+  params: { locale?: string };
 }): Promise<Metadata> {
-  const { locale } = params;
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
+  const appLocale = locale as AppLocale;
   const t = await getTranslations({ locale, namespace: 'contact' });
   return createPageMetadata({
-    locale: locale as AppLocale,
+    locale: appLocale,
     title: t('seo.title'),
     description: t('seo.description'),
     pathname: '/contact',
   });
 }
 
-export default async function ContactPage({ params }: { params: { locale: string } }) {
-  const { locale } = params;
+export default async function ContactPage({ params }: { params: { locale?: string } }) {
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
   const tContact = await getTranslations({ locale, namespace: 'contact' });
 
   const copy: ContactCopy = {

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,21 +1,33 @@
-import Link from "next/link";
-import { getTranslations } from "next-intl/server";
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+import { fallbackLocale, isValidLocale, locales } from '@/lib/i18n';
 
-export default async function LocaleNotFound({ params }: { params: { locale: string } }) {
-  const { locale } = params;
-  const t = await getTranslations({ locale, namespace: "errors" });
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleNotFound({
+  params,
+}: {
+  params: { locale?: string };
+}) {
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
+  const t = await getTranslations({ locale, namespace: 'errors' });
 
   return (
     <div className="mx-auto flex min-h-[60vh] w-full max-w-3xl flex-col items-center justify-center gap-6 px-4 text-center">
       <div className="space-y-2">
-        <h1 className="text-3xl font-semibold text-slate-900">{t("notFoundTitle")}</h1>
-        <p className="text-sm text-slate-600">{t("notFoundDescription")}</p>
+        <h1 className="text-3xl font-semibold text-slate-900">{t('notFoundTitle')}</h1>
+        <p className="text-sm text-slate-600">{t('notFoundDescription')}</p>
       </div>
       <Link
         href={`/${locale}`}
         className="rounded-full bg-brand-600 px-6 py-2 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200"
       >
-        {t("backHome")}
+        {t('backHome')}
       </Link>
     </div>
   );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,33 +1,48 @@
-import Script from "next/script";
-import { getTranslations } from "next-intl/server";
-import Hero from "./components/Hero";
-import ListingsGrid from "./components/ListingsGrid";
-import ArticlesCarousel from "./components/ArticlesCarousel";
-import Testimonials from "./components/Testimonials";
-import FaqAccordion from "./components/FaqAccordion";
-import { JsonLd, buildListingJsonLd, ldOrganization, ldWebsite } from "@/lib/seo";
+import Script from 'next/script';
+import { getTranslations } from 'next-intl/server';
+import Hero from './components/Hero';
+import ListingsGrid from './components/ListingsGrid';
+import ArticlesCarousel from './components/ArticlesCarousel';
+import Testimonials from './components/Testimonials';
+import FaqAccordion from './components/FaqAccordion';
+import { JsonLd, buildListingJsonLd, ldOrganization, ldWebsite } from '@/lib/seo';
 import {
   loadArticles,
   loadFaqs,
   loadHighlights,
   loadListings,
   loadTestimonials,
-} from "@/lib/data/loaders";
-import type { AppLocale } from "@/lib/i18n";
+} from '@/lib/data/loaders';
+import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
 
-export default async function LocaleHome({ params }: { params: { locale: string } }) {
-  const { locale } = params;
-  const [tHome, tListings, tArticles, listings, articles, highlights, faqs, testimonials] =
-    await Promise.all([
-      getTranslations({ locale, namespace: "home" }),
-      getTranslations({ locale, namespace: "listings" }),
-      getTranslations({ locale, namespace: "articles" }),
-      loadListings(),
-      loadArticles(),
-      loadHighlights(),
-      loadFaqs(),
-      loadTestimonials(),
-    ]);
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleHome({ params }: { params: { locale?: string } }) {
+  const requestedLocale = params?.locale ?? '';
+  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
+  const [
+    tHome,
+    tListings,
+    tArticles,
+    listings,
+    articles,
+    highlights,
+    faqs,
+    testimonials,
+  ] = await Promise.all([
+    getTranslations({ locale, namespace: 'home' }),
+    getTranslations({ locale, namespace: 'listings' }),
+    getTranslations({ locale, namespace: 'articles' }),
+    loadListings(),
+    loadArticles(),
+    loadHighlights(),
+    loadFaqs(),
+    loadTestimonials(),
+  ]);
 
   const heroHighlights = highlights.items.map((item) => ({
     value: item.value,
@@ -35,17 +50,19 @@ export default async function LocaleHome({ params }: { params: { locale: string 
   }));
 
   const tagLabels = {
-    panoramic: tListings("tags.panoramic"),
-    cityCore: tListings("tags.cityCore"),
-    resortLiving: tListings("tags.resortLiving"),
-    turnkey: tListings("tags.turnkey"),
-    investmentReady: tListings("tags.investmentReady"),
-    transit: tListings("tags.transit"),
-    exclusive: tListings("tags.exclusive"),
-    privateDock: tListings("tags.privateDock"),
+    panoramic: tListings('tags.panoramic'),
+    cityCore: tListings('tags.cityCore'),
+    resortLiving: tListings('tags.resortLiving'),
+    turnkey: tListings('tags.turnkey'),
+    investmentReady: tListings('tags.investmentReady'),
+    transit: tListings('tags.transit'),
+    exclusive: tListings('tags.exclusive'),
+    privateDock: tListings('tags.privateDock'),
   } satisfies Record<string, string>;
 
-  const listingJsonLd = listings.items.slice(0, 2).map((listing) => buildListingJsonLd(locale as AppLocale, listing));
+  const listingJsonLd = listings.items
+    .slice(0, 2)
+    .map((listing) => buildListingJsonLd(locale as AppLocale, listing));
 
   return (
     <>
@@ -53,69 +70,73 @@ export default async function LocaleHome({ params }: { params: { locale: string 
       <JsonLd {...ldWebsite(locale as AppLocale)} />
 
       <Hero
-        eyebrow={tHome("hero.eyebrow")}
-        title={tHome("hero.title")}
-        subtitle={tHome("hero.subtitle")}
-        primaryCta={{ label: tHome("hero.ctaPrimary"), href: `/${locale}/contact` }}
-        secondaryCta={{ label: tHome("hero.ctaSecondary"), href: `/${locale}/listings` }}
+        eyebrow={tHome('hero.eyebrow')}
+        title={tHome('hero.title')}
+        subtitle={tHome('hero.subtitle')}
+        primaryCta={{ label: tHome('hero.ctaPrimary'), href: `/${locale}/contact` }}
+        secondaryCta={{ label: tHome('hero.ctaSecondary'), href: `/${locale}/listings` }}
         highlights={heroHighlights}
       />
 
       {listings.issues && (
         <div className="mx-auto mt-6 w-full max-w-4xl rounded-3xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-          {tHome("alerts.listingsFallback")}
+          {tHome('alerts.listingsFallback')}
         </div>
       )}
 
       <ListingsGrid
         initial={listings.items.slice(0, 4)}
-        sectionTitle={tListings("sectionTitle")}
-        sectionSubtitle={tListings("sectionSubtitle")}
+        sectionTitle={tListings('sectionTitle')}
+        sectionSubtitle={tListings('sectionSubtitle')}
         viewAllHref={`/${locale}/listings`}
-        viewAllLabel={tListings("viewAll")}
+        viewAllLabel={tListings('viewAll')}
         tagLabels={tagLabels}
         metrics={{
-          bedrooms: tListings("metrics.bedrooms"),
-          bathrooms: tListings("metrics.bathrooms"),
-          area: tListings("metrics.area"),
+          bedrooms: tListings('metrics.bedrooms'),
+          bathrooms: tListings('metrics.bathrooms'),
+          area: tListings('metrics.area'),
         }}
       />
 
       {articles.issues && (
         <div className="mx-auto w-full max-w-4xl rounded-3xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-          {tHome("alerts.articlesFallback")}
+          {tHome('alerts.articlesFallback')}
         </div>
       )}
 
       <ArticlesCarousel
         initial={articles.items.slice(0, 3)}
-        sectionTitle={tArticles("sectionTitle")}
-        sectionSubtitle={tArticles("sectionSubtitle")}
+        sectionTitle={tArticles('sectionTitle')}
+        sectionSubtitle={tArticles('sectionSubtitle')}
         viewAllHref={`/${locale}/articles`}
-        viewAllLabel={tArticles("viewAll")}
+        viewAllLabel={tArticles('viewAll')}
       />
 
       <Testimonials
         testimonials={testimonials.items}
-        sectionTitle={tHome("testimonials.title")}
-        sectionSubtitle={tHome("testimonials.subtitle")}
+        sectionTitle={tHome('testimonials.title')}
+        sectionSubtitle={tHome('testimonials.subtitle')}
       />
 
       <FaqAccordion
         faqs={faqs.items}
-        sectionTitle={tHome("faq.title")}
-        sectionSubtitle={tHome("faq.subtitle")}
+        sectionTitle={tHome('faq.title')}
+        sectionSubtitle={tHome('faq.subtitle')}
       />
 
       <section id="contact" className="py-20">
         <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-6 rounded-3xl bg-brand-600 px-6 py-16 text-center text-white shadow-soft">
-          <h2 className="text-2xl font-semibold sm:text-3xl">{tHome("contactCTA.title")}</h2>
-          <p className="max-w-3xl text-sm text-brand-50/90">{tHome("contactCTA.subtitle")}</p>
+          <h2 className="text-2xl font-semibold sm:text-3xl">
+            {tHome('contactCTA.title')}
+          </h2>
+          <p className="max-w-3xl text-sm text-brand-50/90">
+            {tHome('contactCTA.subtitle')}
+          </p>
           <a
             href={`/${locale}/contact`}
             className="inline-flex items-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-brand-600 transition hover:bg-slate-100"
           >
-            {tHome("contactCTA.cta")}
+            {tHome('contactCTA.cta')}
           </a>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- normalize locale resolution across localized pages and not-found handling
- restrict prerendered params to supported locales for home, articles, contact, and article detail routes
- ensure metadata, translations, and links rely on validated locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f69c5f20832b886c898f34af74b7