### PR TITLE
Handle optional locales in listings page

### DIFF
--- a/src/app/[locale]/components/ListingsGrid.tsx
+++ b/src/app/[locale]/components/ListingsGrid.tsx
@@ -78,7 +78,8 @@ export default function ListingsGrid({
     });
   }, [listings, normalizedQuery, normalizedTag, resolvedLocale, t]);
 
-  const showViewAll = Boolean(viewAllHref && viewAllLabel);
+  const viewAllLink =
+    viewAllHref && viewAllLabel ? { href: viewAllHref, label: viewAllLabel } : null;
 
   return (
     <section id="listings" className="section-gradient scroll-mt-24 py-16">
@@ -90,12 +91,12 @@ export default function ListingsGrid({
             </h2>
             <p className="mt-2 max-w-2xl text-sm text-slate-600">{sectionSubtitle}</p>
           </div>
-          {showViewAll ? (
+          {viewAllLink ? (
             <Link
-              href={viewAllHref}
+              href={viewAllLink.href}
               className="inline-flex items-center rounded-full border border-brand-200 px-4 py-2 text-sm font-semibold text-brand-600 transition hover:border-brand-300 hover:text-brand-700"
             >
-              {viewAllLabel}
+              {viewAllLink.label}
             </Link>
           ) : null}
         </div>

--- a/src/app/[locale]/listings/page.tsx
+++ b/src/app/[locale]/listings/page.tsx
@@ -17,29 +17,35 @@ export function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: { locale: string };
+  params: { locale?: string };
 }): Promise<Metadata> {
-  const { locale } = params;
-  const resolvedLocale = isValidLocale(locale) ? locale : fallbackLocale;
-  const t = await getTranslations({ locale: resolvedLocale, namespace: 'listings' });
+  const requestedLocale = params?.locale ?? '';
+  const resolvedLocale = isValidLocale(requestedLocale)
+    ? requestedLocale
+    : fallbackLocale;
+  const locale = resolvedLocale as AppLocale;
+  const t = await getTranslations({ locale, namespace: 'listings' });
   return createPageMetadata({
-    locale: resolvedLocale as AppLocale,
+    locale,
     title: t('seo.title'),
     description: t('seo.description'),
     pathname: '/listings',
   });
 }
 
-export default async function ListingsPage({ params }: { params: { locale: string } }) {
-  const requestedLocale = params.locale;
-  const locale = isValidLocale(requestedLocale) ? requestedLocale : fallbackLocale;
+export default async function ListingsPage({ params }: { params: { locale?: string } }) {
+  const requestedLocale = params?.locale ?? '';
+  const resolvedLocale = isValidLocale(requestedLocale)
+    ? requestedLocale
+    : fallbackLocale;
+  const locale = resolvedLocale as AppLocale;
   const [tListings, listings] = await Promise.all([
     getTranslations({ locale, namespace: 'listings' }),
     loadListings(),
   ]);
 
   const listingJsonLd = listings.items.map((listing) =>
-    buildListingJsonLd(locale as AppLocale, listing),
+    buildListingJsonLd(locale, listing),
   );
 
   const tagLabels = {


### PR DESCRIPTION
## Summary
- allow listings metadata and page loaders to accept missing locale params and fall back to the default locale
- resolve locales before use and reuse the resolved AppLocale throughout server logic
- tighten listings grid view-all link rendering to ensure a definite href when displayed

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d2fb116fd0832baa4b719dc11cbf55