### PR TITLE
Allow Turnstile bypass for test keys in development

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -23,6 +23,10 @@ const BodySchema = z.object({
 type Body = z.infer<typeof BodySchema>;
 
 async function verifyTurnstile(token: string, ip?: string | null) {
+  if (process.env.NODE_ENV !== 'production' && TURNSTILE_SECRET_KEY?.startsWith('1x')) {
+    return true;
+  }
+
   if (!TURNSTILE_SECRET_KEY) {
     console.error('TURNSTILE_SECRET_KEY is not configured');
     return false;


### PR DESCRIPTION
## Summary
- skip Turnstile verification when running outside production with a test key so local usage works by default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3785b5f44832bbee6e8830dc390dd