### PR TITLE
Wrap Breadcrumbs in Suspense

### DIFF
--- a/src/app/[locale]/articles/[slug]/page.tsx
+++ b/src/app/[locale]/articles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Script from 'next/script';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { loadArticles } from '@/lib/data/loaders';
 import { formatDate } from '@/lib/utils';
@@ -72,7 +73,9 @@ export default async function ArticleDetail({
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs />
+      <Suspense fallback={null}>
+        <Breadcrumbs />
+      </Suspense>
       <article className="mt-8 space-y-6">
         <header className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-brand-500">

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import Script from 'next/script';
 import Link from 'next/link';
+import { Suspense } from 'react';
 import Breadcrumbs from '../components/Breadcrumbs';
 import { loadArticles } from '@/lib/data/loaders';
 import { formatDate } from '@/lib/utils';
@@ -53,7 +54,9 @@ export default async function ArticlesPage({ params }: { params: { locale?: stri
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs />
+      <Suspense fallback={null}>
+        <Breadcrumbs />
+      </Suspense>
       <header className="mt-8 space-y-3">
         <h1 className="text-3xl font-semibold text-slate-900">
           {tArticles('sectionTitle')}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ContactForm, { type ContactCopy } from './ContactForm';
 import { createPageMetadata } from '@/lib/seo';
@@ -55,7 +56,9 @@ export default async function ContactPage({ params }: { params: { locale?: strin
 
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs />
+      <Suspense fallback={null}>
+        <Breadcrumbs />
+      </Suspense>
       <div className="mt-8 space-y-4">
         <h1 className="text-3xl font-semibold text-slate-900">{tContact('title')}</h1>
         <p className="text-sm text-slate-600">{tContact('subtitle')}</p>

--- a/src/app/[locale]/listings/page.tsx
+++ b/src/app/[locale]/listings/page.tsx
@@ -61,7 +61,9 @@ export default async function ListingsPage({ params }: { params: { locale?: stri
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
-      <Breadcrumbs />
+      <Suspense fallback={null}>
+        <Breadcrumbs />
+      </Suspense>
       <div className="mt-8 space-y-4">
         <h1 className="text-3xl font-semibold text-slate-900">
           {tListings('sectionTitle')}


### PR DESCRIPTION
## Summary
- wrap Breadcrumbs components with Suspense to defer rendering until ready
- add missing Suspense imports where needed

## Testing
- npm run lint *(fails: existing lint errors in scripts/repo-dump.mjs and src/lib/i18n.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d38e2ab540832ba63f382c84042e6b