### PR TITLE
Add npm script for i18n sync command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky",
     "i18n:audit": "node scripts/i18n-audit.mjs",
     "i18n:fill": "node scripts/i18n-fill.mjs",
+    "i18n:sync": "node scripts/i18n-sync.mjs",
     "repo:dump:single": "node scripts/repo-dump.mjs --single --out reports/REPO-DUMP.md",
     "repo:dump:split": "node scripts/repo-dump.mjs --out reports --split",
     "repo:dump:all": "node scripts/repo-dump.mjs --single --out reports/REPO-ALL.md --include-dotfiles --include-env --include-binaries --b64-binaries"


### PR DESCRIPTION
## Summary
- add the `i18n:sync` npm script so the i18n sync tool can be invoked via npm scripts

## Testing
- npm run i18n:sync

------
https://chatgpt.com/codex/tasks/task_e_68d4c069c3d4832b874c477b43ec43e7