### PR TITLE
Adjust ContactForm react-hook-form imports

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -9,7 +9,8 @@ import React, {
   useTransition,
 } from 'react';
 import { Turnstile } from '@marsidev/react-turnstile';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
 import {


### PR DESCRIPTION
## Summary
- adjust ContactForm to import `useForm` directly from `react-hook-form` while keeping `Controller` usage
- ensure the zod resolver import stays aligned with the updated setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a21e3f40832b8ccf4e82f650b4b8