### PR TITLE
Refactor page transition into client component

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation';
 import { Analytics } from '@vercel/analytics/react';
 import Script from 'next/script';
 import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
-import { AnimatePresence, motion } from 'framer-motion';
 import Providers from './providers';
 import LayoutShell from './components/LayoutShell';
 import { buildOrganizationJsonLd, generatePageMetadata } from '@/lib/seo';
@@ -16,6 +15,7 @@ import {
 } from '@/lib/i18n';
 import { loadArticles, loadListings } from '@/lib/data/loaders';
 import { createStaticKey } from '@/lib/swr-config';
+import ClientPageTransition from '@/components/ClientPageTransition';
 
 export async function generateStaticParams() {
   return ['th', 'en', 'zh-CN', 'zh-TW', 'my', 'ru'].map((locale) => ({ locale }));
@@ -96,18 +96,9 @@ export default async function LocaleLayout({
               <Script id="org-jsonld" type="application/ld+json">
                 {jsonLd}
               </Script>
-              <AnimatePresence mode="wait">
-                <motion.div
-                  key={locale}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -2 }}
-                  transition={{ duration: 0.18, ease: 'easeOut' }}
-                  className="min-h-full"
-                >
-                  {children}
-                </motion.div>
-              </AnimatePresence>
+              <ClientPageTransition fallbackLocale={locale}>
+                {children}
+              </ClientPageTransition>
             </LayoutShell>
           </Suspense>
         </Providers>

--- a/src/components/ClientPageTransition.tsx
+++ b/src/components/ClientPageTransition.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { PropsWithChildren } from 'react';
+import { usePathname } from 'next/navigation';
+import { useLocale } from 'next-intl';
+import { AnimatePresence, motion } from 'framer-motion';
+
+interface ClientPageTransitionProps extends PropsWithChildren {
+  /**
+   * Optional locale that can be provided as a fallback.
+   */
+  fallbackLocale?: string;
+}
+
+export default function ClientPageTransition({
+  children,
+  fallbackLocale,
+}: ClientPageTransitionProps) {
+  const pathname = usePathname();
+  const localeFromHook = useLocale();
+
+  const locale = localeFromHook ?? fallbackLocale ?? 'default';
+  const transitionKey = `${locale}:${pathname ?? ''}`;
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={transitionKey}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -2 }}
+        transition={{ duration: 0.18, ease: 'easeOut' }}
+        className="min-h-full"
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated ClientPageTransition client component that animates page changes using locale and pathname as the key
- update the locale layout to consume the new component while keeping the server component free of framer-motion imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6bf185ccc832ba47eaeb446213902