### PR TITLE
Add skeleton UI fallback and lazy load client sections

### DIFF
--- a/src/app/[locale]/articles/[slug]/page.tsx
+++ b/src/app/[locale]/articles/[slug]/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Script from 'next/script';
+import dynamic from 'next/dynamic';
 import { getTranslations } from 'next-intl/server';
-import { Suspense } from 'react';
-import Breadcrumbs from '../../components/Breadcrumbs';
+import Skeleton from '@/components/ui/Skeleton';
 import { loadArticles } from '@/lib/data/loaders';
 import { formatDate } from '@/lib/utils';
 import { createPageMetadata, getAbsoluteUrl } from '@/lib/seo';
 import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+const Breadcrumbs = dynamic(() => import('../../components/Breadcrumbs'), {
+  loading: () => <Skeleton className="h-4 w-40" />,
+});
 
 const stripArticlesNs = (key: string) =>
   key.startsWith('articles.') ? key.replace(/^articles\./, '') : key;
@@ -76,9 +80,7 @@ export default async function ArticleDetail({
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <Suspense fallback={null}>
-        <Breadcrumbs />
-      </Suspense>
+      <Breadcrumbs />
       <article className="mt-8 space-y-6">
         <header className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-brand-500">

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -2,12 +2,16 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import Script from 'next/script';
 import Link from 'next/link';
-import { Suspense } from 'react';
-import Breadcrumbs from '../components/Breadcrumbs';
+import dynamic from 'next/dynamic';
+import Skeleton from '@/components/ui/Skeleton';
 import { loadArticles } from '@/lib/data/loaders';
 import { formatDate } from '@/lib/utils';
 import { createPageMetadata, getAbsoluteUrl } from '@/lib/seo';
 import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+const Breadcrumbs = dynamic(() => import('../components/Breadcrumbs'), {
+  loading: () => <Skeleton className="h-4 w-40" />,
+});
 
 const stripArticlesNs = (key: string) =>
   key.startsWith('articles.') ? key.replace(/^articles\./, '') : key;
@@ -57,9 +61,7 @@ export default async function ArticlesPage({ params }: { params: { locale?: stri
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
-      <Suspense fallback={null}>
-        <Breadcrumbs />
-      </Suspense>
+      <Breadcrumbs />
       <header className="mt-8 space-y-3">
         <h1 className="text-3xl font-semibold text-slate-900">
           {tArticles('sectionTitle')}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,10 +1,18 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { Suspense } from 'react';
-import Breadcrumbs from '../components/Breadcrumbs';
-import ContactForm, { type ContactCopy } from './ContactForm';
+import dynamic from 'next/dynamic';
+import Skeleton from '@/components/ui/Skeleton';
+import type { ContactCopy } from './ContactForm';
 import { createPageMetadata } from '@/lib/seo';
 import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+const Breadcrumbs = dynamic(() => import('../components/Breadcrumbs'), {
+  loading: () => <Skeleton className="h-4 w-40" />,
+});
+
+const ContactForm = dynamic(() => import('./ContactForm'), {
+  loading: () => <Skeleton className="h-[520px] w-full" />,
+});
 
 export const dynamicParams = false;
 
@@ -56,9 +64,7 @@ export default async function ContactPage({ params }: { params: { locale?: strin
 
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
-      <Suspense fallback={null}>
-        <Breadcrumbs />
-      </Suspense>
+      <Breadcrumbs />
       <div className="mt-8 space-y-4">
         <h1 className="text-3xl font-semibold text-slate-900">{tContact('title')}</h1>
         <p className="text-sm text-slate-600">{tContact('subtitle')}</p>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import { Analytics } from '@vercel/analytics/react';
 import Script from 'next/script';
 import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
 import Providers from './providers';
-import LayoutShell from './components/LayoutShell';
+import Skeleton from '@/components/ui/Skeleton';
 import { buildOrganizationJsonLd, generatePageMetadata } from '@/lib/seo';
 import {
   getLocaleDirection,
@@ -16,6 +17,17 @@ import {
 import { loadArticles, loadListings } from '@/lib/data/loaders';
 import { createStaticKey } from '@/lib/swr-config';
 import ClientPageTransition from '@/components/ClientPageTransition';
+
+const LayoutShell = dynamic(() => import('./components/LayoutShell'), {
+  loading: () => (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <Skeleton className="h-16 w-full" />
+      <div className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+        <Skeleton className="h-full w-full" />
+      </div>
+    </div>
+  ),
+});
 
 export async function generateStaticParams() {
   return ['th', 'en', 'zh-CN', 'zh-TW', 'my', 'ru'].map((locale) => ({ locale }));

--- a/src/app/[locale]/listings/page.tsx
+++ b/src/app/[locale]/listings/page.tsx
@@ -1,12 +1,24 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import { getTranslations } from 'next-intl/server';
-import Breadcrumbs from '../components/Breadcrumbs';
-import ListingsSearchClient from './ListingsSearchClient';
+import Skeleton from '@/components/ui/Skeleton';
 import { loadListings } from '@/lib/data/loaders';
 import { buildListingJsonLd, createPageMetadata } from '@/lib/seo';
 import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+const Breadcrumbs = dynamic(() => import('../components/Breadcrumbs'), {
+  loading: () => <Skeleton className="h-4 w-40" />,
+});
+
+const ListingsSearchClient = dynamic(() => import('./ListingsSearchClient'), {
+  loading: () => (
+    <div className="mt-8 space-y-6">
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-[420px] w-full" />
+    </div>
+  ),
+});
 
 export const dynamicParams = false;
 
@@ -61,29 +73,25 @@ export default async function ListingsPage({ params }: { params: { locale?: stri
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
-      <Suspense fallback={null}>
-        <Breadcrumbs />
-      </Suspense>
+      <Breadcrumbs />
       <div className="mt-8 space-y-4">
         <h1 className="text-3xl font-semibold text-slate-900">
           {tListings('sectionTitle')}
         </h1>
         <p className="text-sm text-slate-600">{tListings('directorySubtitle')}</p>
       </div>
-      <Suspense fallback={null}>
-        <ListingsSearchClient
-          locale={locale as AppLocale}
-          initial={listings.items}
-          sectionTitle={tListings('sectionTitle')}
-          sectionSubtitle={tListings('directorySubtitle')}
-          tagLabels={tagLabels}
-          metrics={{
-            bedrooms: tListings('metrics.bedrooms'),
-            bathrooms: tListings('metrics.bathrooms'),
-            area: tListings('metrics.area'),
-          }}
-        />
-      </Suspense>
+      <ListingsSearchClient
+        locale={locale as AppLocale}
+        initial={listings.items}
+        sectionTitle={tListings('sectionTitle')}
+        sectionSubtitle={tListings('directorySubtitle')}
+        tagLabels={tagLabels}
+        metrics={{
+          bedrooms: tListings('metrics.bedrooms'),
+          bathrooms: tListings('metrics.bathrooms'),
+          area: tListings('metrics.area'),
+        }}
+      />
       <Script id="listings-directory-jsonld" type="application/ld+json">
         {JSON.stringify(listingJsonLd)}
       </Script>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,10 +1,7 @@
 import Script from 'next/script';
+import dynamic from 'next/dynamic';
 import { getTranslations } from 'next-intl/server';
-import Hero from './components/Hero';
-import ListingsGrid from './components/ListingsGrid';
-import ArticlesCarousel from './components/ArticlesCarousel';
-import Testimonials from './components/Testimonials';
-import FaqAccordion from './components/FaqAccordion';
+import Skeleton from '@/components/ui/Skeleton';
 import { JsonLd, buildListingJsonLd, ldOrganization, ldWebsite } from '@/lib/seo';
 import {
   loadArticles,
@@ -14,6 +11,56 @@ import {
   loadTestimonials,
 } from '@/lib/data/loaders';
 import { fallbackLocale, isValidLocale, locales, type AppLocale } from '@/lib/i18n';
+
+const Hero = dynamic(() => import('./components/Hero'), {
+  loading: () => (
+    <section className="relative overflow-hidden bg-gradient-to-b from-white via-slate-50 to-slate-100">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+        <Skeleton className="h-64 w-full" />
+      </div>
+    </section>
+  ),
+});
+
+const ListingsGrid = dynamic(() => import('./components/ListingsGrid'), {
+  loading: () => (
+    <section id="listings" className="section-gradient scroll-mt-24 py-16">
+      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
+        <Skeleton className="h-80 w-full" />
+      </div>
+    </section>
+  ),
+});
+
+const ArticlesCarousel = dynamic(() => import('./components/ArticlesCarousel'), {
+  loading: () => (
+    <section id="articles" className="scroll-mt-24 py-16">
+      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
+        <Skeleton className="h-72 w-full" />
+      </div>
+    </section>
+  ),
+});
+
+const Testimonials = dynamic(() => import('./components/Testimonials'), {
+  loading: () => (
+    <section className="py-16">
+      <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+        <Skeleton className="h-72 w-full" />
+      </div>
+    </section>
+  ),
+});
+
+const FaqAccordion = dynamic(() => import('./components/FaqAccordion'), {
+  loading: () => (
+    <section className="py-16">
+      <div className="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+        <Skeleton className="h-72 w-full" />
+      </div>
+    </section>
+  ),
+});
 
 export const dynamicParams = false;
 
@@ -49,7 +96,7 @@ export default async function LocaleHome({ params }: { params: { locale?: string
     label: tHome(
       item.labelKey.startsWith('home.')
         ? item.labelKey.slice('home.'.length)
-        : item.labelKey
+        : item.labelKey,
     ),
   }));
 

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,19 @@
+import { forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('animate-pulse rounded-xl bg-slate-200/80', className)}
+      {...props}
+    />
+  ),
+);
+
+Skeleton.displayName = 'Skeleton';
+
+export { Skeleton };
+export default Skeleton;


### PR DESCRIPTION
## Summary
- add a reusable Skeleton UI component for animated placeholders
- lazy load heavy client-side sections with next/dynamic across locale pages and layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c70225f8832ba9d6eef99503cf41