### PR TITLE
Scope flag icon styles to country dropdown

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import './CountrySelect';
 import React, {
   useCallback,
   useEffect,

--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -1,0 +1,5 @@
+import 'flag-icons/css/flag-icons.min.css';
+
+// This module exists solely to scope the flag icon styles to the country dropdown.
+// Import it alongside components that render the flag icon classes.
+export {};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,3 @@
-@import 'flag-icons/css/flag-icons.min.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import 'flag-icons/css/flag-icons.min.css';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { createRootMetadata } from '@/lib/seo';


### PR DESCRIPTION
## Summary
- remove the global flag-icon stylesheet import
- ensure the contact form’s country selector module owns the flag-icon stylesheet so it only loads when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c83c2a4c832ba3b171f3ece1dbf0