### PR TITLE
Sort contact countries by dial code

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -118,7 +118,19 @@ export default function ContactForm({
 }) {
   const t = useTranslations('contact');
   const sortedCountries = useMemo(
-    () => [...COUNTRIES].sort((a, b) => a.name.localeCompare(b.name, 'en')),
+    () =>
+      [...COUNTRIES].sort((a, b) => {
+        const dialA = Number.parseInt(a.dialCode?.replace(/[^\d]/g, '') ?? '', 10);
+        const dialB = Number.parseInt(b.dialCode?.replace(/[^\d]/g, '') ?? '', 10);
+        const valueA = Number.isNaN(dialA) ? Number.POSITIVE_INFINITY : dialA;
+        const valueB = Number.isNaN(dialB) ? Number.POSITIVE_INFINITY : dialB;
+
+        if (valueA !== valueB) {
+          return valueA - valueB;
+        }
+
+        return a.code.localeCompare(b.code, 'en');
+      }),
     [],
   );
   const defaultCountry = React.useMemo(


### PR DESCRIPTION
## Summary
- sort contact form countries by their numeric dial code in ascending order
- fall back to ISO code comparison when dial codes match to ensure deterministic ordering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e5ce0a08832b91a52823a94acf1f