### PR TITLE
Adjust currency select width

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -508,7 +508,7 @@ export default function ContactForm({
               <div className="flex gap-2">
                 <CurrencySelect
                   labelledBy="budget-label"
-                  className="w-20 min-w-[84px] md:w-24"
+                  className="w-16 min-w-[72px] md:w-20"
                   value={budgetCurrency}
                   onChange={(next) => {
                     setBudgetCurrency(next);


### PR DESCRIPTION
## Summary
- narrow the currency selector in the contact form budget row to better fit the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e91cb340832bb2c1e87867c044c0