### PR TITLE
Adjust contact select dropdown alignment

### DIFF
--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -92,8 +92,6 @@ export default function CountrySelect({
       </SelectTrigger>
 
       <SelectContent
-        side="bottom"
-        align="start"
         sideOffset={6}
         className="min-w-[220px] max-w-[260px] overflow-x-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
       >

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -59,8 +59,6 @@ export default function CurrencySelect({
       </SelectTrigger>
 
       <SelectContent
-        side="bottom"
-        align="start"
         sideOffset={6}
         className="min-w-[220px] max-w-[260px] overflow-x-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
       >


### PR DESCRIPTION
## Summary
- remove explicit side and align props from contact country and currency select dropdown content
- rely on updated SelectContent defaults while preserving spacing and styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80fa78d08832ba5e9bbbdd3449d3e