### PR TITLE
Adjust spacing and trigger display for contact dropdowns

### DIFF
--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -101,7 +101,7 @@ export default function CountrySelect({
               key={country.code}
               value={country.code}
               textValue={country.dialCode}
-              className="relative flex cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 pr-8 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="grid w-full cursor-pointer grid-cols-[1.25rem_auto_1rem] items-center gap-1.5 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <span aria-hidden className="shrink-0">
                 <span
@@ -112,7 +112,7 @@ export default function CountrySelect({
                 />
               </span>
               <span className="text-sm tabular-nums">{country.dialCode}</span>
-              <SelectItemIndicator className="absolute right-2 text-brand-600">
+              <SelectItemIndicator className="justify-self-end text-brand-600">
                 <CheckIcon aria-hidden className="h-4 w-4" />
               </SelectItemIndicator>
               <span className="sr-only">{country.name}</span>

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -10,7 +10,6 @@ import {
   SelectViewport,
   SelectItem,
   SelectItemIndicator,
-  SelectValue,
 } from '@/components/ui/select';
 import { SUPPORTED_CURRENCIES, type CurrencyCode } from '@/lib/forex';
 
@@ -54,7 +53,7 @@ export default function CurrencySelect({
           className,
         )}
       >
-        <SelectValue className="font-mono tabular-nums" />
+        <span className="font-mono tabular-nums">{value}</span>
         <ChevronDownIcon aria-hidden className="h-4 w-4 opacity-60" />
       </SelectTrigger>
 
@@ -68,10 +67,10 @@ export default function CurrencySelect({
               key={code}
               value={code}
               textValue={code}
-              className="relative flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="grid w-full cursor-pointer grid-cols-[auto_1rem] items-center gap-1.5 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <span className="font-mono tabular-nums">{code}</span>
-              <SelectItemIndicator className="absolute right-2 text-brand-600">
+              <SelectItemIndicator className="justify-self-end text-brand-600">
                 <CheckIcon aria-hidden className="h-4 w-4" />
               </SelectItemIndicator>
             </SelectItem>


### PR DESCRIPTION
## Summary
- update country select items to use a grid layout so the check icon aligns closely with the dial code
- render the currency code directly in the trigger and mirror the tighter grid layout in the dropdown items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81696f02c832b94beef56f59b4db5