### PR TITLE
Adjust contact select indicator alignment

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -505,7 +505,8 @@ export default function ContactForm({
                   <span className="text-xs text-slate-500">{approxThbDisplay}</span>
                 )}
               </div>
-              <div className="flex gap-2">
+              {/* Tighter space between currency selector and amount for visual balance */}
+              <div className="flex gap-1.5 md:gap-2">
                 <CurrencySelect
                   labelledBy="budget-label"
                   className="w-16 min-w-[72px] md:w-20"

--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -101,7 +101,7 @@ export default function CountrySelect({
               key={country.code}
               value={country.code}
               textValue={country.dialCode}
-              className="grid w-full cursor-pointer grid-cols-[1.25rem_auto_1rem] items-center gap-1.5 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex w-full cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <span aria-hidden className="shrink-0">
                 <span
@@ -111,10 +111,13 @@ export default function CountrySelect({
                   )}
                 />
               </span>
-              <span className="text-sm tabular-nums">{country.dialCode}</span>
-              <SelectItemIndicator className="justify-self-end text-brand-600">
-                <CheckIcon aria-hidden className="h-4 w-4" />
-              </SelectItemIndicator>
+              <div className="flex items-center text-sm tabular-nums">
+                <span>{country.dialCode}</span>
+                {/* Make the checkmark sit right after the dial code (no huge gap) */}
+                <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
+                  <CheckIcon aria-hidden className="h-4 w-4" />
+                </SelectItemIndicator>
+              </div>
               <span className="sr-only">{country.name}</span>
             </SelectItem>
           ))}

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -67,12 +67,15 @@ export default function CurrencySelect({
               key={code}
               value={code}
               textValue={code}
-              className="grid w-full cursor-pointer grid-cols-[auto_1rem] items-center gap-1.5 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
-              <span className="font-mono tabular-nums">{code}</span>
-              <SelectItemIndicator className="justify-self-end text-brand-600">
-                <CheckIcon aria-hidden className="h-4 w-4" />
-              </SelectItemIndicator>
+              <div className="flex items-center font-mono tabular-nums">
+                <span>{code}</span>
+                {/* Keep checkmark tight to the currency code and align consistently */}
+                <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
+                  <CheckIcon aria-hidden className="h-4 w-4" />
+                </SelectItemIndicator>
+              </div>
             </SelectItem>
           ))}
         </SelectViewport>


### PR DESCRIPTION
## Summary
- align the country select check indicator closely with the dial code
- update the currency select layout to keep the indicator beside the code
- slightly reduce the gap between the budget currency selector and amount field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d81d5ee8dc832b8673211505f93334