### PR TITLE
Adjust contact selectors check indicator layout

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -505,8 +505,8 @@ export default function ContactForm({
                   <span className="text-xs text-slate-500">{approxThbDisplay}</span>
                 )}
               </div>
-              {/* Tighter space between currency selector and amount for visual balance */}
-              <div className="flex gap-1.5 md:gap-2">
+              <div className="flex items-center gap-1 md:gap-1.5">
+                {/* CurrencySelect */}
                 <CurrencySelect
                   labelledBy="budget-label"
                   className="w-16 min-w-[72px] md:w-20"
@@ -520,6 +520,7 @@ export default function ContactForm({
                     }
                   }}
                 />
+                {/* Amount input */}
                 <input
                   type="text"
                   inputMode="decimal"

--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -93,7 +93,7 @@ export default function CountrySelect({
 
       <SelectContent
         sideOffset={6}
-        className="min-w-[220px] max-w-[260px] overflow-x-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
+        className="min-w-[220px] max-w-[260px] overflow-x-hidden overflow-y-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
       >
         <SelectViewport className="max-h-72 overflow-y-auto py-1 [scrollbar-gutter:stable]">
           {options.map((country) => (
@@ -101,7 +101,7 @@ export default function CountrySelect({
               key={country.code}
               value={country.code}
               textValue={country.dialCode}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <span aria-hidden className="shrink-0">
                 <span
@@ -111,13 +111,13 @@ export default function CountrySelect({
                   )}
                 />
               </span>
-              <div className="flex items-center text-sm tabular-nums">
-                <span>{country.dialCode}</span>
-                {/* Make the checkmark sit right after the dial code (no huge gap) */}
+              {/* dial code + tight checkmark */}
+              <span className="inline-flex items-center">
+                <span className="text-sm tabular-nums">{country.dialCode}</span>
                 <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
                   <CheckIcon aria-hidden className="h-4 w-4" />
                 </SelectItemIndicator>
-              </div>
+              </span>
               <span className="sr-only">{country.name}</span>
             </SelectItem>
           ))}

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -59,7 +59,7 @@ export default function CurrencySelect({
 
       <SelectContent
         sideOffset={6}
-        className="min-w-[220px] max-w-[260px] overflow-x-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
+        className="min-w-[220px] max-w-[260px] overflow-x-hidden overflow-y-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
       >
         <SelectViewport className="max-h-72 overflow-y-auto py-1 [scrollbar-gutter:stable]">
           {SUPPORTED_CURRENCIES.map((code) => (
@@ -67,11 +67,10 @@ export default function CurrencySelect({
               key={code}
               value={code}
               textValue={code}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 pr-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <div className="flex items-center font-mono tabular-nums">
                 <span>{code}</span>
-                {/* Keep checkmark tight to the currency code and align consistently */}
                 <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
                   <CheckIcon aria-hidden className="h-4 w-4" />
                 </SelectItemIndicator>


### PR DESCRIPTION
## Summary
- align the contact country and currency option checkmarks inline with their labels while trimming unnecessary padding
- hide vertical overflow on the contact selects to avoid double scrollbars
- tighten spacing between the currency selector and amount input on the contact form for better balance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8219f47dc832bb23a109210c3f434