### PR TITLE
Adjust contact select dropdown layout

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -505,7 +505,7 @@ export default function ContactForm({
                   <span className="text-xs text-slate-500">{approxThbDisplay}</span>
                 )}
               </div>
-              <div className="flex items-center gap-1 md:gap-1.5">
+              <div className="flex w-full items-center gap-2 md:gap-3">
                 {/* CurrencySelect */}
                 <CurrencySelect
                   labelledBy="budget-label"

--- a/src/app/[locale]/contact/CountrySelect.tsx
+++ b/src/app/[locale]/contact/CountrySelect.tsx
@@ -92,16 +92,18 @@ export default function CountrySelect({
       </SelectTrigger>
 
       <SelectContent
+        position="popper"
+        align="start"
         sideOffset={6}
-        className="min-w-[220px] max-w-[260px] overflow-x-hidden overflow-y-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
+        className="w-auto min-w-[10rem] max-w-[90vw] p-0"
       >
-        <SelectViewport className="max-h-72 overflow-y-auto py-1 [scrollbar-gutter:stable]">
+        <SelectViewport className="max-h-72 overflow-y-auto rounded-2xl border border-slate-200 bg-white py-1 shadow-lg [scrollbar-gutter:stable]">
           {options.map((country) => (
             <SelectItem
               key={country.code}
               value={country.code}
               textValue={country.dialCode}
-              className="flex cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 pr-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex cursor-pointer items-center gap-2 rounded-xl py-2 pl-2 text-left text-sm text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <span aria-hidden className="shrink-0">
                 <span
@@ -114,7 +116,7 @@ export default function CountrySelect({
               {/* dial code + tight checkmark */}
               <span className="inline-flex items-center">
                 <span className="text-sm tabular-nums">{country.dialCode}</span>
-                <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
+                <SelectItemIndicator className="text-brand-600">
                   <CheckIcon aria-hidden className="h-4 w-4" />
                 </SelectItemIndicator>
               </span>

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -58,20 +58,22 @@ export default function CurrencySelect({
       </SelectTrigger>
 
       <SelectContent
+        position="popper"
+        align="start"
         sideOffset={6}
-        className="min-w-[220px] max-w-[260px] overflow-x-hidden overflow-y-hidden rounded-2xl border border-slate-200 bg-white shadow-lg"
+        className="w-auto min-w-[8rem] max-w-[90vw] p-0"
       >
-        <SelectViewport className="max-h-72 overflow-y-auto py-1 [scrollbar-gutter:stable]">
+        <SelectViewport className="max-h-72 overflow-y-auto rounded-2xl border border-slate-200 bg-white py-1 shadow-lg [scrollbar-gutter:stable]">
           {SUPPORTED_CURRENCIES.map((code) => (
             <SelectItem
               key={code}
               value={code}
               textValue={code}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 pr-2 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              className="flex w-full cursor-pointer items-center gap-2 rounded-xl py-2 pl-3 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
             >
               <div className="flex items-center font-mono tabular-nums">
-                <span>{code}</span>
-                <SelectItemIndicator className="ml-1 inline-flex text-brand-600">
+                <span className="tabular-nums">{code}</span>
+                <SelectItemIndicator className="text-brand-600">
                   <CheckIcon aria-hidden className="h-4 w-4" />
                 </SelectItemIndicator>
               </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -182,10 +182,15 @@ SelectTrigger.displayName = 'SelectTrigger';
 
 type SelectContentProps = React.HTMLAttributes<HTMLDivElement> & {
   sideOffset?: number;
+  position?: 'item' | 'popper';
+  align?: 'start' | 'center' | 'end';
 };
 
 export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
-  ({ children, className, sideOffset = 4, ...props }, forwardedRef) => {
+  (
+    { children, className, sideOffset = 4, position: _position, align: _align, ...props },
+    forwardedRef,
+  ) => {
     const { open, setOpen, triggerRef, contentRef } = useSelectContext('SelectContent');
     const localRef = React.useRef<HTMLDivElement>(null);
     const mergedRef = React.useMemo(
@@ -233,6 +238,8 @@ export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps
           'absolute left-0 top-full z-50 mt-[var(--select-offset,0px)] w-max origin-top',
           className,
         )}
+        data-position={_position}
+        data-align={_align}
         style={{
           ...(props.style ?? {}),
           // allow Tailwind classes to control width while keeping offset configurable
@@ -304,7 +311,7 @@ export const SelectItem = React.forwardRef<HTMLButtonElement, SelectItemProps>(
           data-state={isSelected ? 'checked' : 'unchecked'}
           {...props}
           ref={forwardedRef}
-          className={className}
+          className={clsx('relative pr-5', className)}
           onClick={(event) => {
             onClick?.(event);
             if (event.defaultPrevented) return;
@@ -340,7 +347,15 @@ export const SelectItemIndicator = React.forwardRef<
     return null;
   }
   return (
-    <span {...props} ref={ref} className={className} data-state="checked">
+    <span
+      {...props}
+      ref={ref}
+      className={clsx(
+        'pointer-events-none absolute right-1 flex h-3.5 w-3.5 items-center justify-center',
+        className,
+      )}
+      data-state="checked"
+    >
       {children}
     </span>
   );


### PR DESCRIPTION
## Summary
- update select component defaults to tighten indicator spacing and support popper alignment props
- size contact page country and currency dropdowns to content and shift styling to the viewport
- tweak budget row spacing for better alignment and keep currency dropdown closing immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d82658bdec832b9bb0a5cf17be3fae