### PR TITLE
Ensure currency select closes reliably

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -505,7 +505,7 @@ export default function ContactForm({
                   <span className="text-xs text-slate-500">{approxThbDisplay}</span>
                 )}
               </div>
-              <div className="flex w-full items-center gap-2 md:gap-3">
+              <div className="flex w-full items-center gap-1 md:gap-1.5">
                 {/* CurrencySelect */}
                 <CurrencySelect
                   labelledBy="budget-label"

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { useState } from 'react';
 import clsx from 'clsx';
 
 import {
@@ -30,7 +30,7 @@ export default function CurrencySelect({
   id,
   className,
 }: CurrencySelectProps) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const labelRelationship = id ? `${labelledBy} ${id}` : labelledBy;
 
   return (
@@ -41,6 +41,7 @@ export default function CurrencySelect({
       onValueChange={(next) => {
         onChange(next as CurrencyCode);
         setOpen(false);
+        requestAnimationFrame(() => setOpen(false));
       }}
       className="w-full"
     >


### PR DESCRIPTION
## Summary
- control the currency selector's open state locally so it always closes immediately after choosing an option
- tighten the spacing between the currency selector and the budget input for a more balanced layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d832058230832bbc6cb54072bda1bb