### PR TITLE
Fix currency select closing behavior and budget spacing

### DIFF
--- a/src/app/[locale]/contact/ContactForm.tsx
+++ b/src/app/[locale]/contact/ContactForm.tsx
@@ -509,7 +509,7 @@ export default function ContactForm({
                 {/* CurrencySelect */}
                 <CurrencySelect
                   labelledBy="budget-label"
-                  className="w-16 min-w-[72px] md:w-20"
+                  className="shrink-0"
                   value={budgetCurrency}
                   onChange={(next) => {
                     setBudgetCurrency(next);
@@ -525,7 +525,7 @@ export default function ContactForm({
                   type="text"
                   inputMode="decimal"
                   aria-invalid={fieldState.error ? 'true' : 'false'}
-                  className="flex-1 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200"
+                  className="min-w-0 flex-1 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200"
                   placeholder={budgetPlaceholder}
                   value={budgetInput}
                   onChange={(event) => {

--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import {
@@ -31,57 +31,78 @@ export default function CurrencySelect({
   className,
 }: CurrencySelectProps) {
   const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const labelRelationship = id ? `${labelledBy} ${id}` : labelledBy;
 
-  return (
-    <Select
-      open={open}
-      onOpenChange={setOpen}
-      value={value}
-      onValueChange={(next) => {
-        onChange(next as CurrencyCode);
-        setOpen(false);
-        requestAnimationFrame(() => setOpen(false));
-      }}
-      className="w-full"
-    >
-      <SelectTrigger
-        id={id}
-        aria-label="Currency"
-        aria-labelledby={labelRelationship}
-        className={clsx(
-          'flex h-10 w-full items-center justify-between gap-2 rounded-2xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200',
-          className,
-        )}
-      >
-        <span className="font-mono tabular-nums">{value}</span>
-        <ChevronDownIcon aria-hidden className="h-4 w-4 opacity-60" />
-      </SelectTrigger>
+  useEffect(() => {
+    if (!open) return;
 
-      <SelectContent
-        position="popper"
-        align="start"
-        sideOffset={6}
-        className="w-auto min-w-[5rem] max-w-[90vw] p-0"
+    const handlePointerDown = (event: PointerEvent) => {
+      const element = containerRef.current;
+      if (!element) return;
+
+      if (!element.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef}>
+      <Select
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onValueChange={(next) => {
+          onChange(next as CurrencyCode);
+          setOpen(false);
+        }}
+        className="w-full"
       >
-        <SelectViewport className="max-h-72 overflow-y-auto rounded-2xl border border-slate-200 bg-white py-1 shadow-lg [scrollbar-gutter:stable]">
-          {SUPPORTED_CURRENCIES.map((code) => (
-            <SelectItem
-              key={code}
-              value={code}
-              textValue={code}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-xl py-2 pl-3 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
-            >
-              <div className="flex items-center font-mono tabular-nums">
-                <span className="tabular-nums">{code}</span>
-                <SelectItemIndicator className="text-brand-600">
-                  <CheckIcon aria-hidden className="h-4 w-4" />
-                </SelectItemIndicator>
-              </div>
-            </SelectItem>
-          ))}
-        </SelectViewport>
-      </SelectContent>
-    </Select>
+        <SelectTrigger
+          id={id}
+          aria-label="Currency"
+          aria-labelledby={labelRelationship}
+          className={clsx(
+            'flex h-10 w-full items-center justify-between gap-2 rounded-2xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200',
+            className,
+          )}
+        >
+          <span className="font-mono tabular-nums">{value}</span>
+          <ChevronDownIcon aria-hidden className="h-4 w-4 opacity-60" />
+        </SelectTrigger>
+
+        <SelectContent
+          position="popper"
+          align="start"
+          sideOffset={6}
+          className="w-auto min-w-[5rem] max-w-[90vw] p-0"
+        >
+          <SelectViewport className="max-h-72 overflow-y-auto rounded-2xl border border-slate-200 bg-white py-1 shadow-lg [scrollbar-gutter:stable]">
+            {SUPPORTED_CURRENCIES.map((code) => (
+              <SelectItem
+                key={code}
+                value={code}
+                textValue={code}
+                className="flex w-full cursor-pointer items-center gap-2 rounded-xl py-2 pl-3 text-left text-sm font-medium text-slate-700 transition-colors data-[state=checked]:bg-brand-50 data-[state=checked]:text-brand-700"
+              >
+                <div className="flex items-center font-mono tabular-nums">
+                  <span className="tabular-nums">{code}</span>
+                  <SelectItemIndicator className="text-brand-600">
+                    <CheckIcon aria-hidden className="h-4 w-4" />
+                  </SelectItemIndicator>
+                </div>
+              </SelectItem>
+            ))}
+          </SelectViewport>
+        </SelectContent>
+      </Select>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- close the currency dropdown when clicking outside while keeping the current width behavior
- ensure the select closes immediately after choosing a currency
- tighten spacing in the budget row so the currency picker stays compact and the amount input can shrink

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d839d139f4832b9e3455ce80792e15