### PR TITLE
Fix currency select width handling

### DIFF
--- a/src/app/[locale]/contact/CurrencySelect.tsx
+++ b/src/app/[locale]/contact/CurrencySelect.tsx
@@ -69,7 +69,7 @@ export default function CurrencySelect({
       onOpenChange={setOpen}
       value={value}
       onValueChange={handleValueChange}
-      className="w-full"
+      className="inline-block w-auto"
     >
       <SelectTrigger
         ref={triggerRef}


### PR DESCRIPTION
## Summary
- keep the currency select wrapper from stretching to full width so it stays compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d91bd765ac832ba3f0fac4c87b6fdf