### PR TITLE
Improve contact form layout and Turnstile handling

### DIFF
--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -63,7 +63,7 @@ export default async function ContactPage({ params }: { params: { locale?: strin
   };
 
   return (
-    <div className="mx-auto w-full max-w-4xl px-4 py-16 sm:px-6 lg:px-8 2xl:max-w-5xl">
+    <div className="mx-auto w-full max-w-4xl overflow-x-hidden px-3 py-16 sm:px-6 lg:px-8">
       <Breadcrumbs />
       <div className="mt-8 space-y-4">
         <h1 className="text-3xl font-semibold text-slate-900 sm:text-4xl md:text-5xl">

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -193,7 +193,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     },
     "submit": "Send message",
     "sending": "Sending...",

--- a/src/messages/my.json
+++ b/src/messages/my.json
@@ -211,7 +211,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     }
   },
   "errors": {

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -211,7 +211,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     }
   },
   "errors": {

--- a/src/messages/th.json
+++ b/src/messages/th.json
@@ -211,7 +211,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     }
   },
   "errors": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -211,7 +211,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     }
   },
   "errors": {

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -211,7 +211,7 @@
       "budget": "1,000,000.00"
     },
     "hints": {
-      "budgetThb": "≈ {amount} บาท"
+      "budgetThb": "≈ {amount} THB"
     }
   },
   "errors": {


### PR DESCRIPTION
## Summary
- make the budget inputs fully responsive and adjust THB hint placement
- prune duplicate Turnstile widgets while forcing the compact size
- hide horizontal overflow on the contact page container and rename the THB hint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da28085ad8832b98114a8953c16b91